### PR TITLE
TensorFlow compilation error C2100: illegal indirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,3 +544,6 @@ Here’s how you can check the version of TensorFlow you used for training.
 4. Check the TensorFlow version by issuing `tf.__version__` . It will respond with the version of TensorFlow. This is the version that you used for training. 
 
 #### Bazel configuration session for building GPU-enabled TensorFlow
+
+#### Building TensorFlow from source
+In case you run into error `error C2100: illegal indirection` during TensorFlow compilation, simply edit the file `tensorflow-build\tensorflow\tensorflow\core\framework\op_kernel.h`, go to line 405, and change `reference operator*() { return (*list_)[i_]; }` to `reference operator*() const { return (*list_)[i_]; }`. Credits go to: https://github.com/tensorflow/tensorflow/issues/15925#issuecomment-499569928


### PR DESCRIPTION
Added resolution to problem "error C2100" during TF compilation.